### PR TITLE
Added missing elements to bootstrap argo

### DIFF
--- a/.bootstrap/namespace.yaml
+++ b/.bootstrap/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-gitops-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/.bootstrap/operator-group.yaml
+++ b/.bootstrap/operator-group.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  upgradeStrategy: Default

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ export gitops_repo=https://github.com/redhat-developer/openshift-virtualization-
 export cluster_name=hub #<your hub cluster name, typically "hub">
 export cluster_base_domain=$(oc get ingress.config.openshift.io cluster --template={{.spec.domain}} | sed -e "s/^apps.//")
 export platform_base_domain=${cluster_base_domain#*.}
+oc apply -f .bootstrap/namespace.yaml
+oc apply -f .bootstrap/operator-group.yaml
 oc apply -f .bootstrap/subscription.yaml
 oc apply -f .bootstrap/cluster-rolebinding.yaml
 sleep 60
@@ -55,4 +57,3 @@ See [here](./gitops-approach.md) for more information on how to use this repo.
 ## Ansible Automation Platform
 
 TODO
-


### PR DESCRIPTION
Noticed there was a couple of missing steps when deploying OpenShift GitOps on a totally clean/vanilla cluster; required namespace and operator group